### PR TITLE
Fix DB executor warning

### DIFF
--- a/custom_components/bosch/sensor/recording.py
+++ b/custom_components/bosch/sensor/recording.py
@@ -8,6 +8,7 @@ from .statistic_helper import StatisticHelper
 
 from ..const import SIGNAL_RECORDING_UPDATE_BOSCH, UNITS_CONVERTER, VALUE
 from .base import BoschBaseSensor
+from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.models import (
     StatisticData,
 )
@@ -101,7 +102,7 @@ class RecordingSensor(BoschBaseSensor, StatisticHelper):
     async def _insert_statistics(self) -> None:
         """Insert external statistics."""
         _sum = 0
-        last_stats = await self.hass.async_add_executor_job(
+        last_stats = await get_instance(self.hass).async_add_executor_job(
             get_last_statistics, self.hass, 1, self.statistic_id, True
         )
         today = dt_util.now()


### PR DESCRIPTION
Before this change, the following warning was constantly spammed in my HA
development environment:

```
2022-07-11 20:15:19.933 WARNING (SyncWorker_6) [homeassistant.helpers.frame] Detected code that accesses the database without the database executor; Use homeassistant.components.recorder.get_instance(hass).async_add_executor_job() for faster database operations. Please report this issue.
```