### PR TITLE
Fix _state value

### DIFF
--- a/custom_components/bosch/sensor/base.py
+++ b/custom_components/bosch/sensor/base.py
@@ -108,7 +108,7 @@ class BoschBaseSensor(BoschEntity, SensorEntity):
             if data.get(INVALID, False):
                 self._state = None
             else:
-                if _state := data.get(VALUE, INVALID) in (INVALID, "unavailable"):
+                if (_state := data.get(VALUE, INVALID)) in (INVALID, "unavailable"):
                     self._state = None
                 else:
                     self._state = _state


### PR DESCRIPTION
I used the master branch in my Home Assistant install (installed in config directory as I dont use HACS) and noticed the enabled sensors all had the values of "False" but I could see the values in the attributes of the entity.

After some debugging of sensor base.py I noticed _state was set to False as it was being set to the result of the IF check not the value of the value attribute from data

wrapping the walrus operator in brackets fixes it