### PR TITLE
fix: allow python 3.12 by patching aioxmpp

### DIFF
--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -1,6 +1,6 @@
 """Platform to control a Bosch IP thermostats units."""
 from __future__ import annotations
-import aiohttp
+import aioxmpp
 import asyncio
 import logging
 import random


### PR DESCRIPTION
This patches aioxmpp when it detects that ssl.check_hostname does not exist. As this check is outsourced to openssl on python >= 3.12 at connection time we can safely set this to True.

This should make this component compatible we newer home assistant versions on python 3.12.