### PR TITLE
Import helper instead of getting it through deprecated `hass.helpers`

### DIFF
--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable
 from typing import Any
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import voluptuous as vol
 from bosch_thermostat_client.const import (
     DHW,
@@ -244,8 +245,8 @@ class BoschGatewayEntry:
 
         if await self.async_init_bosch():
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_connection)
-            self.hass.helpers.dispatcher.async_dispatcher_connect(
-                SIGNAL_BOSCH, self.get_signals
+            async_dispatcher_connect(
+                self.hass, SIGNAL_BOSCH, self.get_signals
             )
             for component in self.supported_platforms:
                 if component == SOLAR:


### PR DESCRIPTION
See https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/ for more information.