### PR TITLE
Avoid deprecated `hass.components`

### DIFF
--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from collections.abc import Awaitable
 from typing import Any
 
+from homeassistant.components.persistent_notification import async_create as async_create_persistent_notification
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from bosch_thermostat_client.const import (
@@ -180,7 +181,8 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry):
 
 def create_notification_firmware(hass: HomeAssistant, msg):
     """Create notification about firmware to the user."""
-    hass.components.persistent_notification.async_create(
+    async_create_persistent_notification(
+        hass,
         title="Bosch info",
         message=(
             "There are problems with config of your thermostat.\n"

--- a/custom_components/bosch/manifest.json
+++ b/custom_components/bosch/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bosch thermostat",
   "documentation": "https://github.com/bosch-thermostat/home-assistant-bosch-custom-component",
   "issue_tracker": "https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues",
-  "dependencies": ["network"],
+  "dependencies": ["network", "persistent_notification"],
   "after_dependencies": ["http", "recorder"],
   "codeowners": ["@pszafer"],
   "requirements": ["bosch-thermostat-client==v0.25.1"],


### PR DESCRIPTION
See https://developers.home-assistant.io/blog/2024/02/27/deprecate-bind-hass-and-hass-components/ for more information.