### PR TITLE
Replace deprecated call to `async_forward_entry_setup`

### DIFF
--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -250,15 +250,10 @@ class BoschGatewayEntry:
             async_dispatcher_connect(
                 self.hass, SIGNAL_BOSCH, self.get_signals
             )
-            for component in self.supported_platforms:
-                if component == SOLAR:
-                    continue
-                asyncio.run_coroutine_threadsafe(
-                    self.hass.config_entries.async_forward_entry_setup(
-                        self.config_entry, component
-                    ),
-                    self.hass.loop
-                )
+            await self.hass.config_entries.async_forward_entry_setups(
+                self.config_entry,
+                [component for component in self.supported_platforms if component != SOLAR]
+            )
             device_registry = dr.async_get(self.hass)
             device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,


### PR DESCRIPTION
Forwarding setup to config entry platforms should nowadays be done by awaiting `hass.config_entries.async_forward_entry_setups`.

See https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/ for more information.