### PR TITLE
Read DB files asynchronously

### DIFF
--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -31,7 +31,7 @@ from bosch_thermostat_client.exceptions import (
 )
 from bosch_thermostat_client.version import __version__ as LIBVERSION
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import callback, HomeAssistant
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_ADDRESS,
@@ -249,7 +249,7 @@ class BoschGatewayEntry:
         if await self.async_init_bosch():
             self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_connection)
             async_dispatcher_connect(
-                self.hass, SIGNAL_BOSCH, self.get_signals
+                self.hass, SIGNAL_BOSCH, self.async_get_signals
             )
             await self.hass.config_entries.async_forward_entry_setups(
                 self.config_entry,
@@ -274,7 +274,8 @@ class BoschGatewayEntry:
             return True
         return False
 
-    def get_signals(self) -> None:
+    @callback
+    def async_get_signals(self) -> None:
         """Prepare update after all entities are loaded."""
         if not self._signal_registered and all(
             k in self.hass.data[DOMAIN][self.uuid] for k in self.supported_platforms

--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -322,7 +322,7 @@ class BoschGatewayEntry:
             custom_db = load_json(self.hass.config.path(CUSTOM_DB), default=None)
             if custom_db:
                 _LOGGER.info("Loading custom db file.")
-                self.gateway.custom_initialize(custom_db)
+                await self.gateway.custom_initialize(custom_db)
         if self.gateway.database:
             supported_bosch = await self.gateway.get_capabilities()
             for supported in supported_bosch:


### PR DESCRIPTION
Should solve one of the warnings reported in #420.

See https://github.com/bosch-thermostat/bosch-thermostat-client-python/pull/43.

Fixes warnings in Home Assistant like:

```
2024-06-16 21:44:01.785 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to open inside the event loop by custom integration 'bosch' at custom_components/bosch/__init__.py, line 303: await self.gateway.check_connection() (offender: /usr/local/lib/python3.12/site-packages/bosch_thermostat_client/db/__init__.py, line 35: with open(file, "r") as db_file:), please create a bug report at https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 223, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 209, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 190, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 672, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 639, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1988, in _run_once
    handle._run()
  File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 165, in async_setup_component
    result = await _async_setup_component(hass, domain, config)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 447, in _async_setup_component
    await asyncio.gather(
  File "/usr/src/homeassistant/homeassistant/setup.py", line 449, in <genexpr>
    create_eager_task(
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 37, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 742, in async_setup_locked
    await self.async_setup(hass, integration=integration)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 594, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/config/custom_components/bosch/__init__.py", line 149, in async_setup_entry
    _init_status: bool = await gateway_entry.async_init()
  File "/config/custom_components/bosch/__init__.py", line 246, in async_init
    if await self.async_init_bosch():
  File "/config/custom_components/bosch/__init__.py", line 303, in async_init_bosch
    await self.gateway.check_connection()
```