### PR TITLE
Import `save_json` from the correct place

### DIFF
--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -46,10 +46,11 @@ from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
     async_track_time_interval,
 )
+from homeassistant.helpers.json import save_json
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
-from homeassistant.util.json import load_json, save_json
+from homeassistant.util.json import load_json
 
 from custom_components.bosch.switch import SWITCH
 


### PR DESCRIPTION
TL;DR: Without this fix, the integration will stop working in HA 2024.8.

It turns out that importing `save_json` from `homeassistant.util.json` has been deprecated since https://github.com/home-assistant/core/pull/88099. Curiously enough, I have at least not seen any warnings logged about it anywhere. Maybe because it would only be triggered when one does a manual Bosch scan in HA?

In any case, now that the deprecated method has been cleaned up in https://github.com/home-assistant/core/pull/121069, I noticed that the integration had stopped working in my development instance.

```
2024-07-18 18:02:25.373 ERROR (MainThread) [homeassistant.setup] Setup failed for custom integration 'bosch': Unable to import component: cannot import name 'save_json' from 'homeassistant.util.json' (/workspaces/core/homeassistant/util/json.py)
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/loader.py", line 1007, in async_get_component
    comp = await self.hass.async_add_import_executor_job(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/loader.py", line 1067, in _get_component
    ComponentProtocol, importlib.import_module(self.pkg_path)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/util/loop.py", line 200, in protected_loop_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/workspaces/core/config/custom_components/bosch/__init__.py", line 53, in <module>
    from homeassistant.util.json import load_json, save_json
ImportError: cannot import name 'save_json' from 'homeassistant.util.json' (/workspaces/core/homeassistant/util/json.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspaces/core/homeassistant/setup.py", line 333, in _async_setup_component
    component = await integration.async_get_component()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/loader.py", line 1027, in async_get_component
    self._component_future.result()
  File "/workspaces/core/homeassistant/loader.py", line 1019, in async_get_component
    comp = self._get_component()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/loader.py", line 1067, in _get_component
    ComponentProtocol, importlib.import_module(self.pkg_path)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/util/loop.py", line 200, in protected_loop_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/workspaces/core/config/custom_components/bosch/__init__.py", line 53, in <module>
    from homeassistant.util.json import load_json, save_json
ImportError: cannot import name 'save_json' from 'homeassistant.util.json' (/workspaces/core/homeassistant/util/json.py)
```
