### PR TITLE
Fix Put String Service to not require response. Fixes #397

### DIFF
--- a/custom_components/bosch/services.py
+++ b/custom_components/bosch/services.py
@@ -182,8 +182,7 @@ def async_register_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         DOMAIN,
         SERVICE_PUT_STRING,
         async_handle_put,
-        SERVICE_PUT_STRING_SCHEMA,
-        supports_response=SupportsResponse.ONLY
+        SERVICE_PUT_STRING_SCHEMA
     )
     hass.services.async_register(
         DOMAIN,


### PR DESCRIPTION
The Service PUT_STRING was configured so that it required a response. This caused the error: "The action requires responses and must be called with return_response=True." when calling the service.

Removed the requirement and made it similar to PUT_FLOAT.

Fixes #397.