### PR TITLE
Add gateway claiming step and fix client library dependency

### DIFF
--- a/custom_components/bosch/__init__.py
+++ b/custom_components/bosch/__init__.py
@@ -74,6 +74,7 @@ from .const import (
     INTERVAL,
     NOTIFICATION_ID,
     RECORDING_INTERVAL,
+    REFRESH_TOKEN,
     SCAN_INTERVAL,
     SIGNAL_BINARY_SENSOR_UPDATE_BOSCH,
     SIGNAL_BOSCH,
@@ -85,6 +86,7 @@ from .const import (
     SIGNAL_SOLAR_UPDATE_BOSCH,
     SIGNAL_SWITCH,
     SOLAR,
+    TOKEN_EXPIRES_AT,
     UUID,
     WATER_HEATER,
 )
@@ -148,8 +150,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         host=entry.data[CONF_ADDRESS],
         protocol=entry.data[CONF_PROTOCOL],
         device_type=entry.data[CONF_DEVICE_TYPE],
-        access_key=entry.data[ACCESS_KEY],
-        access_token=entry.data[ACCESS_TOKEN],
+        access_key=entry.data.get(ACCESS_KEY, ""),
+        access_token=entry.data.get(ACCESS_TOKEN, ""),
+        refresh_token=entry.data.get(REFRESH_TOKEN),
+        token_expires_at=entry.data.get(TOKEN_EXPIRES_AT),
         entry=entry,
     )
     hass.data[DOMAIN][uuid] = {BOSCH_GATEWAY_ENTRY: gateway_entry}
@@ -206,7 +210,8 @@ class BoschGatewayEntry:
     """Bosch gateway entry config class."""
 
     def __init__(
-        self, hass, uuid, host, protocol, device_type, access_key, access_token, entry
+        self, hass, uuid, host, protocol, device_type, access_key, access_token, entry,
+        refresh_token=None, token_expires_at=None,
     ) -> None:
         """Init Bosch gateway entry config class."""
         self.hass = hass
@@ -214,6 +219,8 @@ class BoschGatewayEntry:
         self._host = host
         self._access_key = access_key
         self._access_token = access_token
+        self._refresh_token = refresh_token
+        self._token_expires_at = token_expires_at
         self._device_type = device_type
         self._protocol = protocol
         self.config_entry = entry
@@ -232,19 +239,31 @@ class BoschGatewayEntry:
     async def async_init(self) -> bool:
         """Init async items in entry."""
         import bosch_thermostat_client as bosch
+        from bosch_thermostat_client.const.easycontrol import EASYCONTROL
 
         _LOGGER.debug("Initializing Bosch integration.")
         self._update_lock = asyncio.Lock()
-        BoschGateway = bosch.gateway_chooser(device_type=self._device_type)
-        self.gateway = BoschGateway(
-            session=async_get_clientsession(self.hass, verify_ssl=False)
-            if self._protocol == HTTP
-            else None,
-            session_type=self._protocol,
-            host=self._host,
-            access_key=self._access_key,
-            access_token=self._access_token,
-        )
+        if self._device_type == EASYCONTROL:
+            from bosch_thermostat_client.gateway.oauth2 import Oauth2Gateway
+            self.gateway = Oauth2Gateway(
+                session=async_get_clientsession(self.hass),
+                device_type=self._device_type,
+                host=self._host,
+                access_token=self._access_token,
+                refresh_token=self._refresh_token,
+                token_expires_at=self._token_expires_at,
+            )
+        else:
+            BoschGateway = bosch.gateway_chooser(device_type=self._device_type)
+            self.gateway = BoschGateway(
+                session=async_get_clientsession(self.hass, verify_ssl=False)
+                if self._protocol == HTTP
+                else None,
+                session_type=self._protocol,
+                host=self._host,
+                access_key=self._access_key,
+                access_token=self._access_token,
+            )
 
         async def close_connection(event) -> None:
             """Close connection with server."""

--- a/custom_components/bosch/config_flow.py
+++ b/custom_components/bosch/config_flow.py
@@ -215,57 +215,136 @@ class BoschFlowHandler(config_entries.ConfigFlow):
                     errors=errors,
                 )
 
-            from bosch_thermostat_client.gateway.oauth2 import Oauth2Gateway
+            self._access_token = self._oauth_connector._access_token
+            self._refresh_token = self._oauth_connector._refresh_token
+            self._token_expires_at = self._oauth_connector._token_expires_at
 
-            access_token = self._oauth_connector._access_token
-            refresh_token = self._oauth_connector._refresh_token
-            token_expires_at = self._oauth_connector._token_expires_at
-
+            # Check if the gateway is already claimed
+            session = async_get_clientsession(self.hass)
             try:
-                gateway = Oauth2Gateway(
-                    session=async_get_clientsession(self.hass),
-                    device_type=EASYCONTROL,
-                    host=self._host,
-                    access_token=access_token,
-                    refresh_token=refresh_token,
-                    token_expires_at=(
-                        token_expires_at.isoformat() if token_expires_at else None
-                    ),
-                )
-                try:
-                    uuid = await gateway.check_connection()
-                except (FirmwareException, UnknownDevice) as err:
-                    create_notification_firmware(hass=self.hass, msg=err)
-                    uuid = gateway.uuid
-            except (DeviceException, EncryptionException) as err:
-                _LOGGER.error("Cannot connect to EasyControl %s: %s", self._host, err)
-                return self.async_abort(reason="faulty_credentials")
+                from aiohttp import ClientTimeout
+                url = f"{Oauth2Connector.POINTTAPI_BASE_URL}"
+                headers = {"Authorization": f"Bearer {self._access_token}"}
+                async with session.get(url, headers=headers, timeout=ClientTimeout(total=10)) as resp:
+                    if resp.status == 200:
+                        gateways = await resp.json()
+                        device_ids = [gw.get("deviceId") for gw in gateways]
+                        if self._host in device_ids:
+                            _LOGGER.debug("Gateway %s already claimed", self._host)
+                            return await self._easycontrol_create_entry()
             except Exception as err:
-                _LOGGER.error("Unexpected error connecting EasyControl %s: %s", self._host, err)
-                return self.async_abort(reason="unknown")
+                _LOGGER.debug("Gateway list check failed: %s", err)
 
-            if uuid:
-                await self.async_set_unique_id(str(uuid))
-                self._abort_if_unique_id_configured()
-
-            return self.async_create_entry(
-                title=gateway.device_name or "Bosch EasyControl",
-                data={
-                    CONF_ADDRESS: self._host,
-                    UUID: uuid,
-                    ACCESS_KEY: "",
-                    ACCESS_TOKEN: access_token,
-                    REFRESH_TOKEN: refresh_token,
-                    TOKEN_EXPIRES_AT: (
-                        token_expires_at.isoformat() if token_expires_at else None
-                    ),
-                    CONF_DEVICE_TYPE: EASYCONTROL,
-                    CONF_PROTOCOL: HTTP,
-                },
+            # Gateway not claimed — ask for credentials to claim it
+            return self.async_show_form(
+                step_id="easycontrol_claim",
+                data_schema=vol.Schema({
+                    vol.Required("access_code"): str,
+                    vol.Required("user_password"): str,
+                }),
+                errors=errors,
             )
 
         # Should not normally reach here (redirected from easycontrol_serial)
         return self.async_abort(reason="unknown")
+
+    async def async_step_easycontrol_claim(self, user_input=None):
+        """Step 3 of EasyControl POINTT OAuth: claim the gateway."""
+        errors = {}
+        if user_input is not None:
+            import json as json_mod
+            session = async_get_clientsession(self.hass)
+            claim_url = f"{Oauth2Connector.POINTTAPI_BASE_URL}"
+            headers = {
+                "Authorization": f"Bearer {self._access_token}",
+                "Content-Type": "application/json",
+            }
+            payload = {
+                "deviceId": self._host,
+                "gatewayPassword": user_input["access_code"],
+                "userPassword": user_input["user_password"],
+            }
+
+            try:
+                from aiohttp import ClientTimeout
+                async with session.post(
+                    claim_url,
+                    headers=headers,
+                    json=payload,
+                    timeout=ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 201:
+                        _LOGGER.info("Successfully claimed gateway %s", self._host)
+                        return await self._easycontrol_create_entry()
+                    else:
+                        body = await resp.text()
+                        _LOGGER.error(
+                            "Gateway claiming failed: HTTP %s - %s", resp.status, body
+                        )
+                        errors["base"] = "cannot_connect"
+            except Exception as err:
+                _LOGGER.error("Gateway claiming error: %s", err)
+                errors["base"] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="easycontrol_claim",
+            data_schema=vol.Schema({
+                vol.Required("access_code"): str,
+                vol.Required("user_password"): str,
+            }),
+            errors=errors,
+        )
+
+    async def _easycontrol_create_entry(self):
+        """Create config entry after successful OAuth + claiming."""
+        from bosch_thermostat_client.gateway.oauth2 import Oauth2Gateway
+
+        access_token = self._access_token
+        refresh_token = self._refresh_token
+        token_expires_at = self._token_expires_at
+
+        try:
+            gateway = Oauth2Gateway(
+                session=async_get_clientsession(self.hass),
+                device_type=EASYCONTROL,
+                host=self._host,
+                access_token=access_token,
+                refresh_token=refresh_token,
+                token_expires_at=(
+                    token_expires_at.isoformat() if token_expires_at else None
+                ),
+            )
+            try:
+                uuid = await gateway.check_connection()
+            except (FirmwareException, UnknownDevice) as err:
+                create_notification_firmware(hass=self.hass, msg=err)
+                uuid = gateway.uuid
+        except (DeviceException, EncryptionException) as err:
+            _LOGGER.error("Cannot connect to EasyControl %s: %s", self._host, err)
+            return self.async_abort(reason="faulty_credentials")
+        except Exception as err:
+            _LOGGER.error("Unexpected error connecting EasyControl %s: %s", self._host, err)
+            return self.async_abort(reason="unknown")
+
+        if uuid:
+            await self.async_set_unique_id(str(uuid))
+            self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=gateway.device_name or "Bosch EasyControl",
+            data={
+                CONF_ADDRESS: self._host,
+                UUID: uuid,
+                ACCESS_KEY: "",
+                ACCESS_TOKEN: access_token,
+                REFRESH_TOKEN: refresh_token,
+                TOKEN_EXPIRES_AT: (
+                    token_expires_at.isoformat() if token_expires_at else None
+                ),
+                CONF_DEVICE_TYPE: EASYCONTROL,
+                CONF_PROTOCOL: HTTP,
+            },
+        )
 
     async def configure_gateway(
         self, device_type, session_type, host, access_token, password=None, session=None

--- a/custom_components/bosch/config_flow.py
+++ b/custom_components/bosch/config_flow.py
@@ -7,6 +7,7 @@ from bosch_thermostat_client.const import HTTP, XMPP
 from bosch_thermostat_client.const.easycontrol import EASYCONTROL
 from bosch_thermostat_client.const.ivt import IVT, IVT_MBLAN
 from bosch_thermostat_client.const.nefit import NEFIT
+from bosch_thermostat_client.connectors.oauth2 import Oauth2Connector
 from bosch_thermostat_client.exceptions import (
     DeviceException,
     EncryptionException,
@@ -26,6 +27,8 @@ from .const import (
     CONF_DEVICE_TYPE,
     CONF_PROTOCOL,
     DOMAIN,
+    REFRESH_TOKEN,
+    TOKEN_EXPIRES_AT,
     UUID,
 )
 
@@ -48,9 +51,12 @@ class BoschFlowHandler(config_entries.ConfigFlow):
         self._choose_type = None
         self._host = None
         self._access_token = None
+        self._refresh_token = None
+        self._token_expires_at = None
         self._password = None
         self._protocol = None
         self._device_type = None
+        self._oauth_connector = None
 
     async def async_step_user(self, user_input=None):
         """Handle flow initiated by user."""
@@ -73,7 +79,15 @@ class BoschFlowHandler(config_entries.ConfigFlow):
                     ),
                     errors=errors,
                 )
-            elif self._choose_type in (NEFIT, EASYCONTROL, IVT_MBLAN):
+            elif self._choose_type == EASYCONTROL:
+                return self.async_show_form(
+                    step_id="easycontrol_serial",
+                    data_schema=vol.Schema(
+                        {vol.Required(CONF_ADDRESS): str}
+                    ),
+                    errors=errors,
+                )
+            elif self._choose_type in (NEFIT, IVT_MBLAN):
                 return await self.async_step_protocol({CONF_PROTOCOL: XMPP})
         return self.async_show_form(
             step_id="choose_type",
@@ -147,6 +161,111 @@ class BoschFlowHandler(config_entries.ConfigFlow):
                 access_token=self._access_token,
                 password=self._password,
             )
+
+    async def async_step_easycontrol_serial(self, user_input=None):
+        """Step 1 of EasyControl POINTT OAuth: enter device serial number."""
+        errors = {}
+        if user_input is not None:
+            self._host = user_input[CONF_ADDRESS].strip()
+            session = async_get_clientsession(self.hass)
+            self._oauth_connector = Oauth2Connector(
+                host=self._host,
+                access_token="",
+                loop=session,
+            )
+            auth_url = self._oauth_connector.build_auth_url()
+            return self.async_show_form(
+                step_id="easycontrol_oauth",
+                data_schema=vol.Schema({vol.Required("redirect_url"): str}),
+                description_placeholders={"auth_url": auth_url},
+                errors=errors,
+            )
+        return self.async_show_form(
+            step_id="easycontrol_serial",
+            data_schema=vol.Schema({vol.Required(CONF_ADDRESS): str}),
+            errors=errors,
+        )
+
+    async def async_step_easycontrol_oauth(self, user_input=None):
+        """Step 2 of EasyControl POINTT OAuth: paste redirect URL, exchange code."""
+        errors = {}
+        if user_input is not None:
+            redirect_url = user_input.get("redirect_url", "").strip()
+            code = self._oauth_connector.extract_code_from_url(redirect_url)
+            if not code:
+                errors["redirect_url"] = "invalid_redirect_url"
+                return self.async_show_form(
+                    step_id="easycontrol_oauth",
+                    data_schema=vol.Schema({vol.Required("redirect_url"): str}),
+                    description_placeholders={
+                        "auth_url": self._oauth_connector.build_auth_url()
+                    },
+                    errors=errors,
+                )
+
+            success = await self._oauth_connector.exchange_code_for_tokens(code)
+            if not success:
+                errors["base"] = "cannot_connect"
+                return self.async_show_form(
+                    step_id="easycontrol_oauth",
+                    data_schema=vol.Schema({vol.Required("redirect_url"): str}),
+                    description_placeholders={
+                        "auth_url": self._oauth_connector.build_auth_url()
+                    },
+                    errors=errors,
+                )
+
+            from bosch_thermostat_client.gateway.oauth2 import Oauth2Gateway
+
+            access_token = self._oauth_connector._access_token
+            refresh_token = self._oauth_connector._refresh_token
+            token_expires_at = self._oauth_connector._token_expires_at
+
+            try:
+                gateway = Oauth2Gateway(
+                    session=async_get_clientsession(self.hass),
+                    device_type=EASYCONTROL,
+                    host=self._host,
+                    access_token=access_token,
+                    refresh_token=refresh_token,
+                    token_expires_at=(
+                        token_expires_at.isoformat() if token_expires_at else None
+                    ),
+                )
+                try:
+                    uuid = await gateway.check_connection()
+                except (FirmwareException, UnknownDevice) as err:
+                    create_notification_firmware(hass=self.hass, msg=err)
+                    uuid = gateway.uuid
+            except (DeviceException, EncryptionException) as err:
+                _LOGGER.error("Cannot connect to EasyControl %s: %s", self._host, err)
+                return self.async_abort(reason="faulty_credentials")
+            except Exception as err:
+                _LOGGER.error("Unexpected error connecting EasyControl %s: %s", self._host, err)
+                return self.async_abort(reason="unknown")
+
+            if uuid:
+                await self.async_set_unique_id(str(uuid))
+                self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(
+                title=gateway.device_name or "Bosch EasyControl",
+                data={
+                    CONF_ADDRESS: self._host,
+                    UUID: uuid,
+                    ACCESS_KEY: "",
+                    ACCESS_TOKEN: access_token,
+                    REFRESH_TOKEN: refresh_token,
+                    TOKEN_EXPIRES_AT: (
+                        token_expires_at.isoformat() if token_expires_at else None
+                    ),
+                    CONF_DEVICE_TYPE: EASYCONTROL,
+                    CONF_PROTOCOL: HTTP,
+                },
+            )
+
+        # Should not normally reach here (redirected from easycontrol_serial)
+        return self.async_abort(reason="unknown")
 
     async def configure_gateway(
         self, device_type, session_type, host, access_token, password=None, session=None

--- a/custom_components/bosch/const.py
+++ b/custom_components/bosch/const.py
@@ -14,6 +14,8 @@ UUID = "uuid"
 
 CONF_PROTOCOL = "http_xmpp"
 CONF_DEVICE_TYPE = "device_type"
+REFRESH_TOKEN = "refresh_token"
+TOKEN_EXPIRES_AT = "token_expires_at"
 
 GATEWAY = "gateway"
 CLIMATE = "climate"

--- a/custom_components/bosch/manifest.json
+++ b/custom_components/bosch/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["network", "persistent_notification"],
   "after_dependencies": ["http", "recorder"],
   "codeowners": ["@pszafer"],
-  "requirements": ["bosch-thermostat-client==v0.28.2"],
+  "requirements": ["bosch-thermostat-client @ git+https://github.com/deric/bosch-thermostat-client-python.git@k30"],
   "version": "0.28.2",
   "zeroconf": ["_buderus._tcp.local."],
   "config_flow": true,

--- a/custom_components/bosch/manifest.json
+++ b/custom_components/bosch/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["network", "persistent_notification"],
   "after_dependencies": ["http", "recorder"],
   "codeowners": ["@pszafer"],
-  "requirements": ["bosch-thermostat-client @ git+https://github.com/deric/bosch-thermostat-client-python.git@k30"],
+  "requirements": ["bosch-thermostat-client @ git+https://github.com/Cerbrus/bosch-thermostat-client-python.git@fix/easycontrol-model-detection"],
   "version": "0.28.2",
   "zeroconf": ["_buderus._tcp.local."],
   "config_flow": true,

--- a/custom_components/bosch/strings.json
+++ b/custom_components/bosch/strings.json
@@ -31,17 +31,25 @@
                 }
               },
             "easycontrol_serial": {
-                "title": "Bosch EasyControl — POINTT API setup (step 1/2)",
+                "title": "Bosch EasyControl — POINTT API setup (step 1/3)",
                 "description": "Enter the serial number of your EasyControl device (e.g. 101714742). You can find it on the device label or in the Bosch EasyControl app.",
                 "data": {
                     "address": "Device serial number"
                 }
             },
             "easycontrol_oauth": {
-                "title": "Bosch EasyControl — POINTT API setup (step 2/2)",
+                "title": "Bosch EasyControl — POINTT API setup (step 2/3)",
                 "description": "1. Open this URL in your browser and log in with your Bosch SingleKey ID account:\n\n{auth_url}\n\n2. After login you will be redirected to a URL starting with `com.bosch.tt.dashtt.pointt://app/login?code=...`. Copy the full URL and paste it below.",
                 "data": {
                     "redirect_url": "Redirect URL (from browser after login)"
+                }
+            },
+            "easycontrol_claim": {
+                "title": "Bosch EasyControl — POINTT API setup (step 3/3)",
+                "description": "Your device needs to be registered with your Bosch account. Enter the credentials from your device label and the EasyControl app.",
+                "data": {
+                    "access_code": "Access code (from device label)",
+                    "user_password": "Password (set in EasyControl app)"
                 }
             }
         },

--- a/custom_components/bosch/strings.json
+++ b/custom_components/bosch/strings.json
@@ -29,10 +29,26 @@
                     "access_token": "Access token",
                     "password": "Password"
                 }
-              }
+              },
+            "easycontrol_serial": {
+                "title": "Bosch EasyControl — POINTT API setup (step 1/2)",
+                "description": "Enter the serial number of your EasyControl device (e.g. 101714742). You can find it on the device label or in the Bosch EasyControl app.",
+                "data": {
+                    "address": "Device serial number"
+                }
+            },
+            "easycontrol_oauth": {
+                "title": "Bosch EasyControl — POINTT API setup (step 2/2)",
+                "description": "1. Open this URL in your browser and log in with your Bosch SingleKey ID account:\n\n{auth_url}\n\n2. After login you will be redirected to a URL starting with `com.bosch.tt.dashtt.pointt://app/login?code=...`. Copy the full URL and paste it below.",
+                "data": {
+                    "redirect_url": "Redirect URL (from browser after login)"
+                }
+            }
         },
         "error": {
-            "service_unavailable": "No service available"
+            "service_unavailable": "No service available",
+            "invalid_redirect_url": "Could not extract OAuth code from URL. Make sure you paste the full redirect URL.",
+            "cannot_connect": "Token exchange failed. Please try again from step 1."
         },
         "abort": {
             "faulty_credentials": "Bad user credentials or wrong IP",

--- a/custom_components/bosch/translations/en.json
+++ b/custom_components/bosch/translations/en.json
@@ -24,6 +24,20 @@
                   "password": "Password"
               }
             },
+          "easycontrol_serial": {
+              "title": "Bosch EasyControl — POINTT API setup (step 1/2)",
+              "description": "Enter the serial number of your EasyControl device (e.g. 101714742). You can find it on the device label or in the Bosch EasyControl app.",
+              "data": {
+                  "address": "Device serial number"
+              }
+          },
+          "easycontrol_oauth": {
+              "title": "Bosch EasyControl — POINTT API setup (step 2/2)",
+              "description": "1. Open this URL in your browser and log in with your Bosch SingleKey ID account:\n\n{auth_url}\n\n2. After login you will be redirected to a URL starting with `com.bosch.tt.dashtt.pointt://app/login?code=...`. Copy the full URL and paste it below.",
+              "data": {
+                  "redirect_url": "Redirect URL (from browser after login)"
+              }
+          },
           "protocol": {
             "title": "Bosch IVT Protocol. HTTP is local. XMPP is cloud!",
             "data": {
@@ -32,7 +46,9 @@
           }
       },
       "error": {
-          "service_unavailable": "No service available"
+          "service_unavailable": "No service available",
+          "invalid_redirect_url": "Could not extract OAuth code from URL. Make sure you paste the full redirect URL.",
+          "cannot_connect": "Token exchange failed. Please try again from step 1."
       },
       "abort": {
           "faulty_credentials": "Bad user credentials or wrong IP",

--- a/custom_components/bosch/translations/en.json
+++ b/custom_components/bosch/translations/en.json
@@ -25,17 +25,25 @@
               }
             },
           "easycontrol_serial": {
-              "title": "Bosch EasyControl — POINTT API setup (step 1/2)",
+              "title": "Bosch EasyControl — POINTT API setup (step 1/3)",
               "description": "Enter the serial number of your EasyControl device (e.g. 101714742). You can find it on the device label or in the Bosch EasyControl app.",
               "data": {
                   "address": "Device serial number"
               }
           },
           "easycontrol_oauth": {
-              "title": "Bosch EasyControl — POINTT API setup (step 2/2)",
+              "title": "Bosch EasyControl — POINTT API setup (step 2/3)",
               "description": "1. Open this URL in your browser and log in with your Bosch SingleKey ID account:\n\n{auth_url}\n\n2. After login you will be redirected to a URL starting with `com.bosch.tt.dashtt.pointt://app/login?code=...`. Copy the full URL and paste it below.",
               "data": {
                   "redirect_url": "Redirect URL (from browser after login)"
+              }
+          },
+          "easycontrol_claim": {
+              "title": "Bosch EasyControl — POINTT API setup (step 3/3)",
+              "description": "Your device needs to be registered with your Bosch account. Enter the credentials from your device label and the EasyControl app.",
+              "data": {
+                  "access_code": "Access code (from device label)",
+                  "user_password": "Password (set in EasyControl app)"
               }
           },
           "protocol": {


### PR DESCRIPTION
Partially fixes #535. Builds on #536 which adds the EasyControl POINTT API OAuth flow.

While testing the setup flow on a CT200 EasyControl (firmware 05.04.00), I found that the integration fails with "Unknown error occurred" because the POINTT API requires devices to be explicitly "claimed" (registered to the user's account) before any resource endpoints are accessible. Without claiming, all API calls return 403 Forbidden.

Note that the OAuth redirect uses a mobile app custom URI scheme (`com.bosch.tt.dashtt.pointt://`) that desktop browsers **cannot** follow. Users currently need to run a separate tool to capture the redirect.
This is far from ideal, but this is the only way I could get the auth flow to function for desktops.

See [Cerbrus/hassio-issue-bosch-thermostat](https://github.com/Cerbrus/hassio-issue-bosch-thermostat) for the tool and full analysis.

## Summary

- **Add `easycontrol_claim` config flow step**: After OAuth token exchange, check if the gateway is already registered via `GET /gateways/`. If not, prompt the user for their device access code (from the label) and user password (from the EasyControl app), then call `POST /gateways/` to claim it.
- **Point client library at fixed fork**: The `bosch-thermostat-client` dependency now references [Cerbrus/bosch-thermostat-client-python@fix/easycontrol-model-detection](https://github.com/Cerbrus/bosch-thermostat-client-python/tree/fix/easycontrol-model-detection), which fixes model detection (`productID` fallback, `exit(1)` → `raise UnknownDevice`), the `systemBus` path, and circuit types for EasyControl devices. A PR for those changes has been submitted separately.

### Claiming API (undocumented, discovered via probing)

```
POST https://pointt-api.bosch-thermotechnology.com/pointt-api/api/v1/gateways/
Authorization: Bearer
Content-Type: application/json
{
  "deviceId": "",
  "gatewayPassword": "",
  "userPassword": ""
}
```

Returns HTTP 201 on success.

## Context

Tested against a CT200 EasyControl (firmware 05.04.00, productID 8737906739, bus EMS1_0, deviceType rrc2) via the POINTT API. The full setup flow (OAuth → claiming → device initialization) completes successfully with these changes.

## Test plan

- [x] Gateway claiming succeeds for unclaimed device
- [x] Claiming step is skipped when gateway is already registered
- [x] Full setup flow completes end-to-end (OAuth → claim → entry created)
- [x] Integration initializes and connects after setup
- [ ] Verify claiming error messages surface correctly in the UI