### PR TITLE
'bosch' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead

### DIFF
--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -46,8 +46,9 @@ class BoschEntity:
 
         device_registry = dr.async_get(self.hass)
 
-        gateway_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, self._uuid)}
+        gateway_device = device_registry.async_get_device_by_identifier(
+            self.hass.config_entries.async_entries(DOMAIN)[0].entry_id,
+            (DOMAIN, self._uuid),
         )
         
         return DeviceInfo(
@@ -58,9 +59,7 @@ class BoschEntity:
             sw_version=self._gateway.firmware,
             hw_version=self._uuid,
             via_device_id=gateway_device.id if gateway_device else None,
-            
         )
-
 
 class BoschClimateWaterEntity(BoschEntity):
     """Bosch climate and water entities base class."""

--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -49,7 +49,7 @@ class BoschEntity:
             name=self.device_name,
             sw_version=self._gateway.firmware,
             hw_version=self._uuid,
-            via_device_id=(DOMAIN, self._uuid),
+            via_device=(DOMAIN, self._uuid),
         )
 
 

--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -47,8 +47,6 @@ class BoschEntity:
         gateway_device = device_registry.async_get_device_by_identifier(
             (DOMAIN, self._uuid)
         )
-
-
         
         return DeviceInfo(
             identifiers=self._domain_identifier,

--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -44,9 +44,12 @@ class BoschEntity:
     def device_info(self) -> DeviceInfo:
         """Get attributes about the device."""
         device_registry = dr.async_get(self.hass)
-        gateway_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, self._uuid)}
+        gateway_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, self._uuid)
         )
+
+
+        
         return DeviceInfo(
             identifiers=self._domain_identifier,
             manufacturer=self._gateway.device_model,

--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -49,7 +49,7 @@ class BoschEntity:
             name=self.device_name,
             sw_version=self._gateway.firmware,
             hw_version=self._uuid,
-            via_device=(DOMAIN, self._uuid),
+            via_device_id=(DOMAIN, self._uuid),
         )
 
 

--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -43,6 +43,12 @@ class BoschEntity:
     @property
     def device_info(self) -> DeviceInfo:
         """Get attributes about the device."""
+
+        device_registry = dr.async_get(self.hass)
+
+        gateway_device = device_registry.async_get_device(
+            identifiers={(DOMAIN, self._uuid)}
+        )
         
         return DeviceInfo(
             identifiers=self._domain_identifier,
@@ -51,6 +57,8 @@ class BoschEntity:
             name=self.device_name,
             sw_version=self._gateway.firmware,
             hw_version=self._uuid,
+            via_device_id=gateway_device.id if gateway_device else None,
+            
         )
 
 

--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -1,6 +1,7 @@
 """Bosch base entity."""
 from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers import device_registry as dr
 from .const import DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP, DOMAIN
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -42,6 +43,10 @@ class BoschEntity:
     @property
     def device_info(self) -> DeviceInfo:
         """Get attributes about the device."""
+        device_registry = dr.async_get(self.hass)
+        gateway_device = device_registry.async_get_device(
+            identifiers={(DOMAIN, self._uuid)}
+        )
         return DeviceInfo(
             identifiers=self._domain_identifier,
             manufacturer=self._gateway.device_model,
@@ -49,7 +54,7 @@ class BoschEntity:
             name=self.device_name,
             sw_version=self._gateway.firmware,
             hw_version=self._uuid,
-            via_device=(DOMAIN, self._uuid),
+            via_device_id=gateway_device.id if gateway_device else None,
         )
 
 

--- a/custom_components/bosch/bosch_entity.py
+++ b/custom_components/bosch/bosch_entity.py
@@ -43,10 +43,6 @@ class BoschEntity:
     @property
     def device_info(self) -> DeviceInfo:
         """Get attributes about the device."""
-        device_registry = dr.async_get(self.hass)
-        gateway_device = device_registry.async_get_device_by_identifier(
-            (DOMAIN, self._uuid)
-        )
         
         return DeviceInfo(
             identifiers=self._domain_identifier,
@@ -55,7 +51,6 @@ class BoschEntity:
             name=self.device_name,
             sw_version=self._gateway.firmware,
             hw_version=self._uuid,
-            via_device_id=gateway_device.id if gateway_device else None,
         )
 
 


### PR DESCRIPTION
Fixed this in HA log:

Logger: homeassistant.helpers.frame
Kilde: helpers/frame.py:348
Første forekomst: 4. september 2026 kl. 20.15.27 (8 forekomster)
Senest logget: 4. september 2026 kl. 20.15.31

Detected that custom integration 'bosch' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead at custom_components/bosch/number.py, line 59: async_add_entities(data[NUMBER]). This will stop working in Home Assistant 2027.8.0, please create a bug report at https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues
Detected that custom integration 'bosch' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead at custom_components/bosch/switch.py, line 63: async_add_entities(data[SWITCH]). This will stop working in Home Assistant 2027.8.0, please create a bug report at https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues
Detected that custom integration 'bosch' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead at custom_components/bosch/sensor/__init__.py, line 132: async_add_entities(data[SENSOR]). This will stop working in Home Assistant 2027.8.0, please create a bug report at https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues
Detected that custom integration 'bosch' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead at custom_components/bosch/sensor/__init__.py, line 133: async_add_entities(data[RECORDING]). This will stop working in Home Assistant 2027.8.0, please create a bug report at https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues
Detected that custom integration 'bosch' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead at custom_components/bosch/binary_sensor.py, line 42: async_add_entities(data[BINARY_SENSOR]). This will stop working in Home Assistant 2027.8.0, please create a bug report at https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues 